### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index,:show]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :text, :category_id, :state_id, :delivery_fee_id, :prefecture_id, :days_to_ship_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :text, :category_id, :state_id, :delivery_fee_id, :prefecture_id, :days_to_ship_id,
+                                 :price, :image).merge(user_id: current_user.id)
   end
-  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index,:show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,8 @@ class Item < ApplicationRecord
     validates :text
   end
 
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: 'は¥300~9,999,999で入力してください'}
+  validates :price,
+            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'は¥300~9,999,999で入力してください' }
   validates :price, numericality: { only_integer: true, message: 'は半角数字で入力してください' }
 
   with_options presence: true, numericality: { other_than: 1, message: 'を選択してください' } do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,8 @@ class User < ApplicationRecord
   validates_format_of :password, with: PASSWORD_REGEX, message: 'には英字と数字の両方を含めて設定してください'
   with_options presence: true do
     validates :nickname
-    validates :first_name, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: "は全角（漢字・ひらがな・カタカナ）で入力してください"}
-    validates :last_name, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: "は全角（漢字・ひらがな・カタカナ）で入力してください"}
+    validates :first_name, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: 'は全角（漢字・ひらがな・カタカナ）で入力してください' }
+    validates :last_name, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: 'は全角（漢字・ひらがな・カタカナ）で入力してください' }
     validates :first_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'はカタカナで入力して下さい。' }
     validates :last_name_kana, presence: true, format: { with: /\A[\p{katakana}\p{blank}ー－]+\z/, message: 'はカタカナで入力して下さい。' }
     validates :birth_date

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <% if @items.count >= 1 %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to "/items/#{item.id}" do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
             <%# 商品購入機能実装後に実装します %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,107 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image,class:"item-box-img" %>
+      <%# 商品購入機能実装時に実装%>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div> %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ <%= @item.price %>
+      </span>
+      <span class="item-postage">
+        <%= DeliveryFee.data[@item.delivery_fee_id-1][:name] %>
+      </span>
+    </div>
+    <% if user_signed_in? %>
+      <% if current_user.id == @item.user.id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% else %>
+        <%# 商品購入機能実装時に実装します%>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
+    <div class="item-explain-box">
+      <span><%= @item.text %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%=  Category.data[(@item.category_id-1)][:name] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= State.data[(@item.state_id-1)][:name] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= DeliveryFee.data[(@item.delivery_fee_id-1)][:name] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= Prefecture.data[(@item.prefecture_id-1)][:name] %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= DaysToShip.data[(@item.days_to_ship_id-1)][:name] %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <a href=“#” class=‘another-item’><%= Category.data[(@item.category_id-1)][:name] %>をもっと見る</a>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,76 +1,76 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-    before do
-      @item = FactoryBot.build(:item)
-    end
+  before do
+    @item = FactoryBot.build(:item)
+  end
 
-    context '商品が登録できる時' do
-      it '必須項目が入力されていれば登録できること' do
-        expect(@item).to be_valid
-      end
+  context '商品が登録できる時' do
+    it '必須項目が入力されていれば登録できること' do
+      expect(@item).to be_valid
     end
+  end
 
-    context '商品が登録できない時' do
-      it 'imageが空だと登録できないこと' do
-        @item.image = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include('出品画像を選択してください')
-      end
-      it 'nameが空だと登録できないこと' do
-        @item.name = ""
-        @item.valid?
-        expect(@item.errors.full_messages).to include('商品名を入力してください')
-      end
-      it 'textが空だと登録できないこと' do
-        @item.text = ""
-        @item.valid?
-        expect(@item.errors.full_messages).to include('商品の説明を入力してください')
-      end
-      it 'category_idが1だと登録できないこと' do
-        @item.category_id = "1"
-        @item.valid?
-        expect(@item.errors.full_messages).to include('カテゴリーを選択してください')
-      end
-      it 'state_idが1だと登録できないこと' do
-        @item.state_id = "1"
-        @item.valid?
-        expect(@item.errors.full_messages).to include('商品の状態を選択してください')
-      end
-      it 'delivery_fee_idが1だと登録できないこと' do
-        @item.delivery_fee_id = "1"
-        @item.valid?
-        expect(@item.errors.full_messages).to include('配送料の負担を選択してください')
-      end
-      it 'prefecture_idが1だと登録できなこと' do
-        @item.prefecture_id = "1"
-        @item.valid?
-        expect(@item.errors.full_messages).to include('発送元の地域を選択してください')
-      end
-      it 'days_to_ship_idが1だと登録できないこと' do
-        @item.days_to_ship_id = "1"
-        @item.valid?
-        expect(@item.errors.full_messages).to include('発送までの日数を選択してください')
-      end
-      it 'priceが空だと登録できないこと' do
-        @item.price = nil
-        @item.valid?
-        expect(@item.errors.full_messages).to include('販売価格は¥300~9,999,999で入力してください', '販売価格は半角数字で入力してください')
-      end
-      it 'priceが299以下だと登録できないこと' do
-        @item.price = 299
-        @item.valid?
-        expect(@item.errors.full_messages).to include('販売価格は¥300~9,999,999で入力してください')
-      end
-      it 'priceが10000000以上だと登録できないこと' do
-        @item.price = 10000000
-        @item.valid?
-        expect(@item.errors.full_messages).to include('販売価格は¥300~9,999,999で入力してください')
-      end
-      it 'priceが半角数字以外では登録できないこと' do
-        @item.price = "３００"
-        @item.valid?
-        expect(@item.errors.full_messages).to include('販売価格は半角数字で入力してください')
-      end
+  context '商品が登録できない時' do
+    it 'imageが空だと登録できないこと' do
+      @item.image = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include('出品画像を選択してください')
     end
+    it 'nameが空だと登録できないこと' do
+      @item.name = ''
+      @item.valid?
+      expect(@item.errors.full_messages).to include('商品名を入力してください')
+    end
+    it 'textが空だと登録できないこと' do
+      @item.text = ''
+      @item.valid?
+      expect(@item.errors.full_messages).to include('商品の説明を入力してください')
+    end
+    it 'category_idが1だと登録できないこと' do
+      @item.category_id = '1'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('カテゴリーを選択してください')
+    end
+    it 'state_idが1だと登録できないこと' do
+      @item.state_id = '1'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('商品の状態を選択してください')
+    end
+    it 'delivery_fee_idが1だと登録できないこと' do
+      @item.delivery_fee_id = '1'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('配送料の負担を選択してください')
+    end
+    it 'prefecture_idが1だと登録できなこと' do
+      @item.prefecture_id = '1'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('発送元の地域を選択してください')
+    end
+    it 'days_to_ship_idが1だと登録できないこと' do
+      @item.days_to_ship_id = '1'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('発送までの日数を選択してください')
+    end
+    it 'priceが空だと登録できないこと' do
+      @item.price = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include('販売価格は¥300~9,999,999で入力してください', '販売価格は半角数字で入力してください')
+    end
+    it 'priceが299以下だと登録できないこと' do
+      @item.price = 299
+      @item.valid?
+      expect(@item.errors.full_messages).to include('販売価格は¥300~9,999,999で入力してください')
+    end
+    it 'priceが10000000以上だと登録できないこと' do
+      @item.price = 10_000_000
+      @item.valid?
+      expect(@item.errors.full_messages).to include('販売価格は¥300~9,999,999で入力してください')
+    end
+    it 'priceが半角数字以外では登録できないこと' do
+      @item.price = '３００'
+      @item.valid?
+      expect(@item.errors.full_messages).to include('販売価格は半角数字で入力してください')
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe User, type: :model do
         expect(@user).to be_valid
       end
       it 'first_nameが漢字・ひらがな・カタカナ（全角）であれば登録できること' do
-        @user.first_name = "名前なまえナマエ"
+        @user.first_name = '名前なまえナマエ'
         expect(@user).to be_valid
       end
       it 'last_nameが漢字・ひらがな・カタカナ（全角）であれば登録できること' do
-        @user.last_name = "名前なまえナマエ"
+        @user.last_name = '名前なまえナマエ'
         expect(@user).to be_valid
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe User, type: :model do
         @user.valid?
         expect(@user.errors.full_messages).to include('パスワードを入力してください')
       end
-      
+
       it 'passwordが5字以下であれば登録できないこと' do
         @user.password = '1234a'
         @user.password_confirmation = '1234a'
@@ -77,9 +77,9 @@ RSpec.describe User, type: :model do
         @user.valid?
         expect(@user.errors.full_messages).to include('姓（全角）を入力してください')
       end
-      
+
       it 'first_nameが漢字・ひらがな・カタカナ（全角）以外では登録できないこと' do
-        @user.first_name = "nameﾅﾏｴ"
+        @user.first_name = 'nameﾅﾏｴ'
         @user.valid?
         expect(@user.errors.full_messages).to include('姓（全角）は全角（漢字・ひらがな・カタカナ）で入力してください')
       end
@@ -88,9 +88,9 @@ RSpec.describe User, type: :model do
         @user.valid?
         expect(@user.errors.full_messages).to include('名（全角）を入力してください')
       end
-      
+
       it 'last_nameが漢字・ひらがな・カタカナ（全角）以外では登録できないこと' do
-        @user.last_name = "nameﾅﾏｴ"
+        @user.last_name = 'nameﾅﾏｴ'
         @user.valid?
         expect(@user.errors.full_messages).to include('名（全角）は全角（漢字・ひらがな・カタカナ）で入力してください')
       end


### PR DESCRIPTION
# What
出品された商品の詳細を表示する機能の実装
※売却済みの商品の画像上に「sold out」の文字を表示する機能は商品購入機能の実装時に実装します
※ログイン状態の出品者でも売却済みの商品に対しては「編集・削除ボタン」が表示されない機能は商品購入機能の実装時に実装します

# Why
furimaアプリに商品の詳細表示機能を実装するため

# 実際の機能画面の画像URL
◯商品出品時に登録した情報が見られるようになっている
https://gyazo.com/d92b0372d4ca88da7a3d1d29f35f062e
◯ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること
https://gyazo.com/fd970f1a6fcc7e3962d48fb489ebc9f2
◯ ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できる
https://gyazo.com/348f527dea08acb2603928b956c9d03a
◯ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されない
https://gyazo.com/4a9b91704f388a069199b774c44b017f
◯ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示される
https://gyazo.com/4f5e00d760edc669a1b5d9a2e23587a5